### PR TITLE
fix the "execute shellscript" issue

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,12 +9,13 @@ USER root
 
 WORKDIR /opt/irisapp
 RUN chown ${ISC_PACKAGE_MGRUSER}:${ISC_PACKAGE_IRISGROUP} /opt/irisapp
+COPY irissession.sh /
+RUN chmod +x /irissession.sh 
 
 USER irisowner
 
 COPY  Installer.cls .
 COPY  src src
-COPY irissession.sh /
 SHELL ["/irissession.sh"]
 
 RUN \


### PR DESCRIPTION
Hi Dave!
Please accept the PR - this fixes Docker execution issue. 
During coping in Windows the executable flag was lost. And this change to dockerfile solves this.